### PR TITLE
Fix for some hotkey modifiers not being recognized

### DIFF
--- a/help.py
+++ b/help.py
@@ -31,6 +31,8 @@ hotmod = {		131072 : "shift",
 
 				262144 : "control",
 
+				262401 : "control",
+
 				393216 : "shift+control",
 
 				524288 : "option",
@@ -46,6 +48,8 @@ hotmod = {		131072 : "shift",
 				1179648 : "shift+command",
 
 				1310720 : "control+command",
+
+				1310985 : "control+command",
 
 				1441792 : "shift+control+command",
 

--- a/help.py
+++ b/help.py
@@ -186,7 +186,10 @@ for item in dirs:
 
 					if "hotmod" in item['config'] and item['config']['hotmod']:
 
-						hotkeys += "\r\n* " + hotmod[item['config']['hotmod']] + " " + item['config']['hotstring']
+						if item['config']['hotmod'] in hotmod:
+							hotkeys += "\r\n* " + hotmod[item['config']['hotmod']] + " " + item['config']['hotstring']
+						else:
+							hotkeys += "\r\n* <font color=\"red\">Error reading hotkey</font>: try re-entering the hotkey in Alfred's preferences"
 
 					else:
 


### PR DESCRIPTION
I'm not sure what causes this, but I had a couple of workflows that didn't use any of the recognized 'hotmod' values. They were fairly old workflows, so perhaps the hotmod values have changed since then. I've added a couple of the 'hotmod' values to the code, and added an error message in the markdown where the hotkey would otherwise have been listed.

Here's a preview of the error message:

![qlmanage](https://f.cloud.github.com/assets/375202/321377/fb31e796-99c2-11e2-9b4f-e8005e59955d.png)
